### PR TITLE
Included error messages

### DIFF
--- a/abs.rho
+++ b/abs.rho
@@ -1,31 +1,31 @@
 new abs in {
-
-  // When an int is submitted
-  contract abs(@{input /\ Int}, return) = {
-    if (input >= 0) {
-      return!(input)
-    }
-    else {
-      return!(-input)
-    }
-  } |
-
-  // Error message
-  contract abs(@{~Int}, return) = {
-    return!("No integer provided")
+  contract abs(@input, return, error) = {
+    new inputChecker in {
+      inputChecker!(input) |
+      for(@{input /\ Int} <= inputChecker) {
+        if (input >= 0) {
+          return!(input)
+        }
+        else {
+          return!(-input)
+        }
+      } |
+      for(@{~Int} <= inputChecker) {
+          error!("No integer provided")
+      }
+    } 
   } |
 
   // Unit tests below
-  new stdout(`rho:io:stdout`) in {
-    abs!(5, *stdout)|
-    abs!(0, *stdout)|
-    abs!(-5, *stdout)|
-    abs!("123", *stdout) |
-    abs!(true, *stdout) |
-    abs!(Nil, *stdout) |
-    abs!(@Nil!(Nil), *stdout) 
+  new stdout(`rho:io:stdout`), stderr(`rho:io:stderr`) in {
+    abs!(5, *stdout, *stderr)|
+    abs!(0, *stdout, *stderr)|
+    abs!(-5, *stdout, *stderr)|
+    abs!("123", *stdout, *stderr) |
+    abs!(true, *stdout, *stderr) |
+    abs!(Nil, *stdout, *stderr) |
+    abs!(@Nil!(Nil), *stdout, *stderr) 
   }
 }
-
 
 

--- a/abs.rho
+++ b/abs.rho
@@ -1,19 +1,24 @@
 new abs in {
+
+  // The abs contract returns the absolute value of an integer and returns an error message if no integer provided
   contract abs(@input, return, error) = {
-    new inputChecker in {
-      inputChecker!(input) |
-      for(@{input /\ Int} <= inputChecker) {
-        if (input >= 0) {
-          return!(input)
+    match input {
+    
+      // if input is an integer
+      integer /\ Int => {
+        if (integer >= 0) {
+          return!(integer)
         }
         else {
-          return!(-input)
+          return!(-integer)
         }
-      } |
-      for(@{~Int} <= inputChecker) {
-          error!("No integer provided")
       }
-    } 
+      
+      // If not an integer
+      _ => {
+        error!("No integer provided")
+      }
+    }
   } |
 
   // Unit tests below

--- a/abs.rho
+++ b/abs.rho
@@ -8,12 +8,8 @@ new abs in {
     }
   } |
 
-  contract abs(@{noInt /\ String}, return) = {
-    return!("provided: String, expected: Integer")
-  }  |
-
-  contract abs(@{noInt /\ Bool}, return) = {
-    return!("provided: Bool, expected: Integer")
+  contract abs(@{{String} \/ {Bool} \/ {ByteArray} \/ {Uri}}, return) = {
+    return!("No integer provided")
   }  |
 
   // Unit tests below
@@ -25,5 +21,8 @@ new abs in {
     abs!(true, *stdout) 
   }
 }
+
+
+
 
 

--- a/abs.rho
+++ b/abs.rho
@@ -6,14 +6,24 @@ new abs in {
     else {
       return!(-input)
     }
-  }
-  |
+  } |
+
+  contract abs(@{noInt /\ String}, return) = {
+    return!("provided: String, expected: Integer")
+  }  |
+
+  contract abs(@{noInt /\ Bool}, return) = {
+    return!("provided: Bool, expected: Integer")
+  }  |
 
   // Unit tests below
   new stdout(`rho:io:stdout`) in {
     abs!(5, *stdout)|
     abs!(0, *stdout)|
     abs!(-5, *stdout)|
-    abs!("123", *stdout)
+    abs!("123", *stdout) |
+    abs!(true, *stdout) 
   }
 }
+
+

--- a/abs.rho
+++ b/abs.rho
@@ -1,4 +1,6 @@
 new abs in {
+
+  // When an int is submitted
   contract abs(@{input /\ Int}, return) = {
     if (input >= 0) {
       return!(input)
@@ -8,9 +10,10 @@ new abs in {
     }
   } |
 
-  contract abs(@{{String} \/ {Bool} \/ {ByteArray} \/ {Uri}}, return) = {
+  // Error message
+  contract abs(@{~Int}, return) = {
     return!("No integer provided")
-  }  |
+  } |
 
   // Unit tests below
   new stdout(`rho:io:stdout`) in {
@@ -18,11 +21,11 @@ new abs in {
     abs!(0, *stdout)|
     abs!(-5, *stdout)|
     abs!("123", *stdout) |
-    abs!(true, *stdout) 
+    abs!(true, *stdout) |
+    abs!(Nil, *stdout) |
+    abs!(@Nil!(Nil), *stdout) 
   }
 }
-
-
 
 
 


### PR DESCRIPTION
- What about Other types (Uri, ByteArray, others?)? 
- Is it possible to print and error message if not Int (exclusive), instead of printing error messages in an inclusive way showed here?